### PR TITLE
Refactor logging to throw intellisense errors

### DIFF
--- a/simgui-ds.json
+++ b/simgui-ds.json
@@ -88,5 +88,10 @@
       "buttonCount": 0,
       "povCount": 0
     }
+  ],
+  "robotJoysticks": [
+    {
+      "guid": "Keyboard0"
+    }
   ]
 }

--- a/src/main/cpp/Robot.cpp
+++ b/src/main/cpp/Robot.cpp
@@ -7,6 +7,8 @@
 #include <frc/DriverStation.h>
 #include <frc2/command/CommandScheduler.h>
 
+#include <iostream>
+
 #include "logging/LogTypes.h"
 #include "logging/Logger.h"
 #include "logging/NTLogManager.h"
@@ -32,6 +34,7 @@ void Robot::RobotPeriodic()
 {
     frc2::CommandScheduler::GetInstance().Run();
     nfr::logger["robot"] << m_container;
+    nfr::logger.Flush();
 }
 
 void Robot::DisabledInit()

--- a/src/main/cpp/Robot.cpp
+++ b/src/main/cpp/Robot.cpp
@@ -7,8 +7,6 @@
 #include <frc/DriverStation.h>
 #include <frc2/command/CommandScheduler.h>
 
-#include <iostream>
-
 #include "logging/LogTypes.h"
 #include "logging/Logger.h"
 #include "logging/NTLogManager.h"

--- a/src/main/cpp/logging/Logger.cpp
+++ b/src/main/cpp/logging/Logger.cpp
@@ -1,5 +1,9 @@
 #include <logging/Logger.h>
 
+#include <iostream>
+#include <memory>
+#include <sstream>
+
 using namespace nfr;
 using namespace std;
 
@@ -54,6 +58,22 @@ const LogContext& LogContext::operator<<(span<string> values) const
 {
     logger->Log(key, values);
     return *this;
+}
+
+Logger::Logger()
+    // Initialize shared stringstreams for logging
+    : original_cout_buf_(std::cout.rdbuf()),
+      original_cerr_buf_(std::cerr.rdbuf()),
+      // Save original streambufs
+      cout_log_stream_(std::make_shared<std::stringstream>()),
+      cerr_log_stream_(std::make_shared<std::stringstream>()),
+      // Initialize tee streambufs with original and log streams
+      cout_tee_buf_(original_cout_buf_, cout_log_stream_),
+      cerr_tee_buf_(original_cerr_buf_, cerr_log_stream_)
+{
+    // Set cout and cerr to use our tee streambufs
+    std::cout.rdbuf(&cout_tee_buf_);
+    std::cerr.rdbuf(&cerr_tee_buf_);
 }
 
 void Logger::Log(const string& key, double value)
@@ -123,6 +143,16 @@ void Logger::Log(const string& key, span<string> values)
 void Logger::AddOutput(shared_ptr<ILogOutput> output)
 {
     outputs.push_back(std::move(output));
+}
+
+void Logger::Flush()
+{
+    std::string cout_log = cout_log_stream_->str();
+    std::string cerr_log = cerr_log_stream_->str();
+    cout_log_stream_->str("");  // Clear the stringstream
+    cerr_log_stream_->str("");  // Clear the stringstream
+    Log("cout", cout_log);
+    Log("cerr", cerr_log);
 }
 
 namespace nfr

--- a/src/main/include/logging/LogTypes.h
+++ b/src/main/include/logging/LogTypes.h
@@ -12,7 +12,6 @@
 #include <units/temperature.h>
 #include <units/voltage.h>
 
-
 namespace nfr
 {
 template <typename T>

--- a/src/main/include/logging/LogTypes.h
+++ b/src/main/include/logging/LogTypes.h
@@ -12,7 +12,6 @@
 #include <units/temperature.h>
 #include <units/voltage.h>
 
-#include <type_traits>
 
 namespace nfr
 {
@@ -36,13 +35,11 @@ inline void Log(const LogContext &logContext, const T &value)
     logContext << degrees.value();
 }
 
-template <>
 inline void Log(const LogContext &logContext, const frc::Rotation2d &value)
 {
     logContext << value.Degrees();
 }
 
-template <>
 inline void Log(const LogContext &logContext, const frc::Pose2d &pose)
 {
     logContext["x"] << pose.X();
@@ -50,7 +47,6 @@ inline void Log(const LogContext &logContext, const frc::Pose2d &pose)
     logContext["rotation"] << pose.Rotation().Degrees();
 }
 
-template <>
 inline void Log(const LogContext &logContext,
                 const frc::Translation2d &translation)
 {
@@ -58,7 +54,6 @@ inline void Log(const LogContext &logContext,
     logContext["y"] << translation.Y();
 }
 
-template <>
 inline void Log(const LogContext &logContext, const frc::Rotation3d &value)
 {
     logContext["roll"] << value.X();
@@ -66,7 +61,6 @@ inline void Log(const LogContext &logContext, const frc::Rotation3d &value)
     logContext["yaw"] << value.Z();
 }
 
-template <>
 inline void Log(const LogContext &logContext,
                 const frc::Translation3d &translation)
 {
@@ -75,7 +69,6 @@ inline void Log(const LogContext &logContext,
     logContext["z"] << translation.Z();
 }
 
-template <>
 inline void Log(const LogContext &logContext, const frc::Pose3d &pose)
 {
     logContext["x"] << pose.X();
@@ -105,7 +98,6 @@ inline void Log(const LogContext &logContext, const T &value)
     logContext << radiansPerSecond.value();
 }
 
-template <>
 inline void Log(const LogContext &logContext, const frc::ChassisSpeeds &speeds)
 {
     logContext["vx"] << speeds.vx;
@@ -113,7 +105,6 @@ inline void Log(const LogContext &logContext, const frc::ChassisSpeeds &speeds)
     logContext["omega"] << speeds.omega;
 }
 
-template <>
 inline void Log(const LogContext &logContext,
                 const frc::SwerveModuleState &state)
 {
@@ -121,7 +112,6 @@ inline void Log(const LogContext &logContext,
     logContext["speed"] << state.speed;
 }
 
-template <>
 inline void Log(const LogContext &logContext,
                 const frc::SwerveModulePosition &position)
 {
@@ -129,14 +119,12 @@ inline void Log(const LogContext &logContext,
     logContext["distance"] << position.distance;
 }
 
-template <>
 inline void Log(const LogContext &logContext, const frc::Transform2d &transform)
 {
     logContext["translation"] << transform.Translation();
     logContext["rotation"] << transform.Rotation();
 }
 
-template <>
 inline void Log(const LogContext &logContext, const frc::Twist2d &twist)
 {
     logContext["dx"] << twist.dx;
@@ -144,14 +132,12 @@ inline void Log(const LogContext &logContext, const frc::Twist2d &twist)
     logContext["dtheta"] << twist.dtheta;
 }
 
-template <>
 inline void Log(const LogContext &logContext, const frc::Transform3d &transform)
 {
     logContext["translation"] << transform.Translation();
     logContext["rotation"] << transform.Rotation();
 }
 
-template <>
 inline void Log(const LogContext &logContext, const frc::Twist3d &twist)
 {
     logContext["dx"] << twist.dx;

--- a/src/main/include/logging/Logger.h
+++ b/src/main/include/logging/Logger.h
@@ -16,15 +16,16 @@ template <typename T>
 concept HasLogMethod = requires(T t, const LogContext& logContext) {
     { t.Log(logContext) } -> std::same_as<void>;
 };
-template<typename T>
+template <typename T>
 concept ExistsLogMethodFor = requires(T t, const LogContext& logContext) {
     { Log(logContext, t) } -> std::same_as<void>;
 };
 
 template <typename T>
-concept ExistsPointerLogMethodFor = requires(T t, const LogContext& logContext) {
-    { Log(logContext, *t) } -> std::same_as<void>;
-};
+concept ExistsPointerLogMethodFor =
+    requires(T t, const LogContext& logContext) {
+        { Log(logContext, *t) } -> std::same_as<void>;
+    };
 template <typename T>
 concept HasPointerLogMethod = requires(T t, const LogContext& logContext) {
     { t->Log(logContext) } -> std::same_as<void>;

--- a/src/main/include/logging/Logger.h
+++ b/src/main/include/logging/Logger.h
@@ -63,7 +63,10 @@ class LogContext
         requires HasPointerLogMethod<T>
     const LogContext& operator<<(T&& value) const
     {
-        Log(*this, std::forward<T>(value));
+        if (value)
+        {
+            value->Log(*this);
+        }
         return *this;
     }
     template <typename T>

--- a/src/main/include/logging/Logger.h
+++ b/src/main/include/logging/Logger.h
@@ -67,6 +67,16 @@ class LogContext
         return *this;
     }
     template <typename T>
+        requires ExistsPointerLogMethodFor<T>
+    const LogContext& operator<<(const T* value) const
+    {
+        if (value)
+        {
+            Log(*this, *value);
+        }
+        return *this;
+    }
+    template <typename T>
         requires HasLogMethod<T>
     const LogContext& operator<<(const T& value) const
     {

--- a/src/main/include/util/GitMetadataLoader.h
+++ b/src/main/include/util/GitMetadataLoader.h
@@ -27,8 +27,7 @@ struct GitMetadata
 
 #include <logging/Logger.h>
 
-template <>
-inline void nfr::Log(const nfr::LogContext& logContext,
+inline void Log(const nfr::LogContext& logContext,
                      const GitMetadata& metadata)
 {
     logContext["branch"] << metadata.branch;

--- a/src/main/include/util/GitMetadataLoader.h
+++ b/src/main/include/util/GitMetadataLoader.h
@@ -27,8 +27,7 @@ struct GitMetadata
 
 #include <logging/Logger.h>
 
-inline void Log(const nfr::LogContext& logContext,
-                     const GitMetadata& metadata)
+inline void Log(const nfr::LogContext& logContext, const GitMetadata& metadata)
 {
     logContext["branch"] << metadata.branch;
     logContext["build_host"] << metadata.build_host;


### PR DESCRIPTION
This now will show errors if you attempt to log an unloggable type. Also, now the Log() function does not have a templated signature by default.